### PR TITLE
[TASK] Temporarily remove roave/security-advisories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
     "typo3/cms-backend": "^10.4 || ^11.0"
   },
   "require-dev": {
-    "roave/security-advisories": "dev-master",
     "typo3/testing-framework": "^6.1",
     "typo3/coding-standards": "^0.4.0",
     "phpstan/phpstan": "^0.12.37",


### PR DESCRIPTION
To fix the CI, we temporarily remove the `roave/security-advisories` package for now.